### PR TITLE
SASS integration fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,15 @@ npm run build
 ```
 
 # Styles
-There are template SASS files at [src/css/](src/css) directory.
-__Change ID of root div to ID of your plugin__ in [template.html](src/partials/template.html) and [SASS files](src/css) in order __to prevent CSS conflicts between plugins__.
+There are template SASS files at [src/css/](src/css).
+
+__Change root tag__ in [SASS files](src/css) __to default Grafana tag (see example below) with ID of your plugin__ in order __to prevent CSS conflicts between plugins__.
+
+Root tag example: panel-plugin-_grafana-plugin-template-webpack_ (where _grafana-plugin-template-webpack_ is ID of your plugin).
 
 If you don't need separate styles for for dark and light themes - follow comments in [module.js](src/module.js).
 
-If you want to use CSS instead of SASS - just change files extensions at [src/css/](src/css) directory
-and in [module.js](src/module.js).
+If you want to use CSS instead of SASS - just change files extensions at [src/css/](src/css) and in [module.js](src/module.js).
 
 # See also
 

--- a/src/css/panel.base.scss
+++ b/src/css/panel.base.scss
@@ -1,5 +1,5 @@
-#grafana-plugin-template-webpack {
-  b {
+panel-plugin-grafana-plugin-template-webpack {
+  .hello {
     font-size: 14pt;
   }
 }

--- a/src/css/panel.dark.scss
+++ b/src/css/panel.dark.scss
@@ -1,5 +1,5 @@
-#grafana-plugin-template-webpack {
-  b {
+panel-plugin-grafana-plugin-template-webpack {
+  .hello b {
     color: white;
   }
 }

--- a/src/css/panel.light.scss
+++ b/src/css/panel.light.scss
@@ -1,5 +1,5 @@
-#grafana-plugin-template-webpack {
-  b {
+panel-plugin-grafana-plugin-template-webpack {
+  .hello b {
     color: black;
   }
 }

--- a/src/partials/template.html
+++ b/src/partials/template.html
@@ -1,3 +1,3 @@
-<div id="grafana-plugin-template-webpack">
+<div class="hello">
   Hello from <b>Template Plugin</b>
 </div>


### PR DESCRIPTION
Fix of PR https://github.com/CorpGlory/grafana-plugin-template-webpack/pull/5
It is better to use default Grafana tag instead of your own HTML ID as root SASS element.
There are reasons why:
- you don't need to create root element by yourself, it is created by Grafana
- editor is located inside of this tag